### PR TITLE
Fix: 문제창이 열려있을 떄 레이아웃 깨짐 수정

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -158,6 +158,10 @@ nav ol li a:not(.active):hover {
 }
 
 @media (max-width: 1200px) {
+    .menu-on.container .contents main {
+        height: 100%;
+    }
+
     .menu-on.container .contents main section {
         width: 100%;
         float: none;


### PR DESCRIPTION
### Summary
- 문제창(nav)가 열려있을 때 레이아웃이 깨지는 오류 수정
<img width="1421" alt="스크린샷 2023-02-22 오전 9 52 50" src="https://user-images.githubusercontent.com/96777064/220498823-dbcace74-072d-4779-907a-ade5e3766a2b.png">