### PR TITLE
Design: 명령어 입력과 터미널이 상단에 위치하도록 레이아웃 수정

### DIFF
--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -3,29 +3,31 @@
 @import './style.css';
 
 body {
-  display:flex;
+  display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height:100vh;
-  
+  min-height: 100vh;
+
 }
 
 header {
   padding: 0 2rem;
 }
 
-.py-terminal   {
-  display: none;
-  margin: 0 2rem 6.4rem;
+main {
+  padding: 2rem;
+  margin-bottom: auto;
 }
 
 footer {
   order: 3;
 }
 
-.py-terminal {
+py-terminal {
+  flex-grow: 1;
   margin: 0 2rem 2rem;
 }
+
 
 .py-error {
   background: none;


### PR DESCRIPTION
### Summary
1. 터미널이 명령창 바로 하단에 위치하도록 수정
<img width="868" alt="image" src="https://user-images.githubusercontent.com/96777064/221076893-f988ab35-58de-4ba9-9ff5-b82278f45e37.png">

2. footer가 화면에서 고정되지 않고 유동적으로 움직이도록 수정
<img width="868" alt="스크린샷 2023-02-24 오전 11 21 40" src="https://user-images.githubusercontent.com/96777064/221076792-abcc2c49-0b50-4d4e-9904-ee54df178e3c.png">
