### PR TITLE
Bugfix/codeexec: 파이썬 실행 페이지 전체적인 레이아웃 수정

### DIFF
--- a/codeexec.html
+++ b/codeexec.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html lang="ko">
+
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Run Python - pyalgo</title>
-    
+
     <!-- pyscript -->
     <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css">
     <script defer src="https://pyscript.net/latest/pyscript.js"></script>
 
-
-
     <py-config>
         packages = [
-            "matplotlib", "pandas", "numpy"
+        "matplotlib", "pandas", "numpy"
         ]
         [[fetch]]
         files = ["./src/py/antigravity.py"]
@@ -23,6 +22,7 @@
     <!-- css -->
     <link rel="stylesheet" href="./src/css/codeexec.css">
 </head>
+
 <body>
     <header>
         <h1>
@@ -40,4 +40,5 @@
         <p>Copyright 2023. <strong>WENIV</strong> All rights reserved.</p>
     </footer>
 </body>
+
 </html>

--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -3,29 +3,31 @@
 @import './style.css';
 
 body {
-  display:flex;
+  display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height:100vh;
-  
+  min-height: 100vh;
+
 }
 
 header {
   padding: 0 2rem;
 }
 
-.py-terminal   {
-  display: none;
-  margin: 0 2rem 6.4rem;
+main {
+  padding: 2rem;
+  margin-bottom: auto;
 }
 
 footer {
   order: 3;
 }
 
-.py-terminal {
+py-terminal {
+  flex-grow: 1;
   margin: 0 2rem 2rem;
 }
+
 
 .py-error {
   background: none;

--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -7,7 +7,6 @@ body {
   flex-direction: column;
   justify-content: space-between;
   min-height: 100vh;
-
 }
 
 header {
@@ -27,7 +26,6 @@ py-terminal {
   flex-grow: 1;
   margin: 0 2rem 2rem;
 }
-
 
 .py-error {
   background: none;
@@ -81,9 +79,12 @@ py-terminal {
 }
 
 .py-repl-output {
-  padding: 2rem;
   margin: 1rem 0 4rem 0;
   background: rgba(0, 0, 0, 0.2);
+}
+
+.py-repl-output div {
+  padding: 2rem;
 }
 
 .ͼb {

--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -82,11 +82,22 @@ py-terminal {
 
 .py-repl-output {
   margin: 1rem 0 4rem 0;
+  padding: 2rem;
   background: rgba(0, 0, 0, 0.2);
 }
 
-.py-repl-output div {
-  padding: 2rem;
+.py-repl-output:empty::after {
+  content: '> 터미널을 확인하세요';
+  color: rgba(255, 255, 255, 0.5);
+}
+
+py-repl:last-child .py-repl-output {
+  padding: 0;
+}
+
+py-repl:last-child .py-repl-output::after {
+  content: none;
+
 }
 
 .ͼb {

--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -2,6 +2,7 @@
 @import './reset.css';
 @import './style.css';
 
+/* layout */
 body {
   display: flex;
   flex-direction: column;
@@ -27,6 +28,7 @@ py-terminal {
   margin: 0 2rem 2rem;
 }
 
+/* design */
 .py-error {
   background: none;
   color: var(--ColorNegative);
@@ -101,4 +103,9 @@ py-terminal {
 
 .ͼg {
   color: var(--codeText);
+}
+
+.py-terminal {
+  background: rgba(0, 0, 0, 0.3);
+  padding: 2rem;
 }


### PR DESCRIPTION
### Summary
1. 결과가 터미널에 출력되는 경우 '> 터미널을 확인하세요' 메시지 출력
<img width="868" alt="image" src="https://user-images.githubusercontent.com/96777064/221124876-815b37ff-8f9f-40e8-8d1d-f18b5fc1ae7d.png">



2.  footer가 화면에서 고정되지 않고 유동적으로 움직이도록 수정
<img width="868" alt="스크린샷 2023-02-24 오전 11 21 40" src="https://user-images.githubusercontent.com/96777064/221076792-abcc2c49-0b50-4d4e-9904-ee54df178e3c.png"/>