### PR TITLE
:lipstick: Edit: btn-fold rotate시 버튼 내부 텍스트 보이는 현상 수정

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -81,6 +81,7 @@ header .btn-fold {
 .btn-fold {
     width: 4rem;
     height: 4rem;
+    color: var(--ColorBg);
     background: var(--ColorBg);
     overflow: hidden;
     border-radius: var(--borderRadius);


### PR DESCRIPTION
-  수정 전 

https://user-images.githubusercontent.com/94890646/221447039-b515ef6a-900a-41c7-9d4c-cec107b4056b.mov

모바일 버전 메뉴 펼칠 때, 왼쪽 위, 아래 텍스트가 보임.


- 수정 후

https://user-images.githubusercontent.com/94890646/221447082-b08b129e-cb4e-4c17-a96e-8ab0b92c1619.mov

텍스트 색상 배경과 동일하게 설정.
