### PR TITLE
Design: 레이아웃 절반 분할 시 짧은 문항 배경이 화면 전체를 차지하도록 수정

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -222,7 +222,6 @@ nav ol li a:not(.active):hover {
     }
 
     .menu-on.container {
-        border: 1px solid rd;
         height: fit-content;
     }
 }
@@ -251,11 +250,19 @@ nav ol li a:not(.active):hover {
     .menu-on-CodeMirror {
         width: 845px;
     }
+
+    
 }
 
 .container .contents {
     display: flex;
     width: 100%;
+}
+
+@media (min-width:1200px) and (max-width:2000px){
+    .menu-on.container .contents main section.description {
+        min-height:Calc(100vh - 60px);
+    }
 }
 
 @media (min-width: 2000px) {
@@ -284,6 +291,16 @@ nav ol li a:not(.active):hover {
         width: 50%;
         float: left;
     }
+    
+    
+    .container .contents main section.description {
+        min-height:Calc(100vh - 120px);
+    }
+
+    .menu-on.container .contents main section.description {
+        min-height:100%;
+    }
+
 
     nav {
         margin-top: 6rem;


### PR DESCRIPTION
<img width="1392" alt="스크린샷 2023-03-02 오전 9 45 36" src="https://user-images.githubusercontent.com/96777064/222301667-0a34cc1d-5daa-49fd-9b55-f733edb4c753.png">
