### PR TITLE
Design: 순서가 있는 리스트의 경우 불렛이 표시되지 않도록 수정

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -403,6 +403,7 @@ nav ol li a:not(.active):hover {
 
 .description .que-list:not(:first-child) {
     margin: 1em 0 0.4em;
+
 }
 
 .description .que-list:not(:first-child) .que-ol-li,
@@ -411,13 +412,15 @@ nav ol li a:not(.active):hover {
     padding-left: 1em;
     line-height: 1.5;
 }
+.description .que-list:not(:first-child) .que-ol-li {
+    padding-left: 0;
+}
 
 .description .que-list:not(:first-child) .que-ol-li:not(:first-child),
 .description .que-list:not(:first-child) .que-ul-li:not(:first-child) {
     margin-top: 0.5rem;
 }
 
-.description .que-list:not(:first-child) .que-ol-li::before,
 .description .que-list:not(:first-child) .que-ul-li::before {
     content: "";
     position: absolute;


### PR DESCRIPTION
- 현재 MD 문서에서 '1. 항목'인 경우 1.까지 `<li>` 내부 요소로 들어가는 현상이 있습니다.
- 추후 파서를 수정하여 내용만 `<li>`에 넣고 list-style을 추가하는 형식으로 수정할 예정입니다.

<img width="412" alt="image" src="https://user-images.githubusercontent.com/96777064/222306884-4a0e753a-fcd6-493e-9855-04c281257de5.png">
*) 예시에 작성된 숫자는 list-style이 아닌 텍스트입니다.

```html
<ol class="que-list">
    <li class="que-ol-li">1. 0 ≤ 토핑수 ≤ 5</li>
    <li class="que-ol-li">2. 토핑은 안내된 토핑 중 선택해야 합니다. (연어, 참치, 닭가슴살, 베이컨, 버섯)</li>
</ol>
```
